### PR TITLE
Add interactive setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ SPNEGO/LDAP authentication on RHEL 9 systems joined to IdM with AD trusts.
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+python setup_wizard.py
 export FLASK_APP=app.py
-flask shell -c "from models import db; db.create_all()"
 flask run
 ```
 
 For production, deploy under Apache using `wsgi.py` and `apache_firmware_maestro.conf`.
-Edit `config.py` to adjust environment specific options.
+Settings configured by the wizard are stored in `.env`. You can edit
+this file or `config.py` for advanced adjustments.

--- a/config.py
+++ b/config.py
@@ -5,6 +5,9 @@ Values can be overridden with environment variables or a .env file.
 
 import os
 from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
 
 BASE_DIR = Path(__file__).resolve().parent
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML==6.0.1
 requests==2.32.3
 ldap3==2.9.1
 python-redfish==1.3.0
+python-dotenv==1.0.1

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1,0 +1,67 @@
+import os
+from pathlib import Path
+import getpass
+
+
+def prompt(question: str, default: str = None, secret: bool = False) -> str:
+    if default:
+        prompt_text = f"{question} [{default}]: "
+    else:
+        prompt_text = f"{question}: "
+    if secret:
+        value = getpass.getpass(prompt_text)
+    else:
+        value = input(prompt_text)
+    return value.strip() or default or ""
+
+
+def main():
+    print("=== Firmware Maestro Setup Wizard ===")
+    base_dir = Path(__file__).resolve().parent
+    db_path = prompt("Database path", str(base_dir / "firmware_maestro.sqlite"))
+    secret_key = prompt("Flask secret key", "change-me")
+    admin_group = prompt("Admin group", "FW_MAESTRO_ADMIN")
+    operator_group = prompt("Operator group", "FW_MAESTRO_OPERATOR")
+    viewer_group = prompt("Viewer group", "FW_MAESTRO_VIEWER")
+    smtp_server = prompt("SMTP server", "localhost")
+    smtp_from = prompt("Email from address", "firmware-maestro@example.com")
+    smtp_port = prompt("SMTP port", "25")
+    vc_host = prompt("vCenter hostname", "vcenter.example.com")
+    vc_user = prompt("vCenter username", "administrator@vsphere.local")
+    vc_pass = prompt("vCenter password", secret=True)
+    idrac_file = prompt("iDRAC credential file", str(base_dir / "idrac_creds.yml"))
+    log_path = prompt("Log file path", str(base_dir / "fm.log"))
+
+    env_lines = [
+        f"FM_DB_PATH={db_path}",
+        f"FM_SECRET_KEY={secret_key}",
+        f"FM_ADMIN_GROUP={admin_group}",
+        f"FM_OPERATOR_GROUP={operator_group}",
+        f"FM_VIEWER_GROUP={viewer_group}",
+        f"FM_SMTP_SERVER={smtp_server}",
+        f"FM_SMTP_FROM={smtp_from}",
+        f"FM_SMTP_PORT={smtp_port}",
+        f"FM_VC_HOST={vc_host}",
+        f"FM_VC_USER={vc_user}",
+        f"FM_VC_PASS={vc_pass}",
+        f"FM_IDRAC_CRED_FILE={idrac_file}",
+        f"FM_LOG_PATH={log_path}",
+    ]
+
+    with open(".env", "w") as f:
+        f.write("\n".join(env_lines))
+    print("Configuration saved to .env")
+
+    for line in env_lines:
+        key, val = line.split("=", 1)
+        os.environ[key] = val
+
+    from app import app, db
+    with app.app_context():
+        db.create_all()
+    print(f"Database initialised at {db_path}")
+    print("Setup complete. Run 'flask run' to start the server.")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Help</h2>
-<p>See README or contact your administrator for assistance.</p>
+<p>For first time setup run <code>python setup_wizard.py</code>.</p>
+<p>See README or contact your administrator for further assistance.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a setup_wizard script to prompt for initial configuration
- load `.env` file automatically
- document first-time setup in the README and help page
- add python-dotenv to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68879e4c39208320864f152b1e39b0e5