### PR TITLE
Enhance user interface and notices

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,10 +111,12 @@ def schedules():
         cron = request.form.get("cron")
         interval = request.form.get("interval")
         dry_run = bool(request.form.get("dry_run"))
+        enabled = bool(request.form.get("enabled", True))
         sched = Schedule(name=name, firmware_path=firmware_path, cron=cron or None,
                          interval_minutes=int(interval) if interval else None,
                          target_group_id=int(group_id) if group_id else None,
-                         dry_run=dry_run)
+                         dry_run=dry_run,
+                         enabled=enabled)
         db.session.add(sched)
         db.session.commit()
         load_schedules()

--- a/static/main.js
+++ b/static/main.js
@@ -1,1 +1,6 @@
-// placeholder for future JS enhancements
+// simple flash message auto-dismiss
+document.addEventListener('DOMContentLoaded', () => {
+  setTimeout(() => {
+    document.querySelectorAll('.flashes li').forEach(li => li.style.display = 'none');
+  }, 4000);
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,9 +1,19 @@
-body { font-family: sans-serif; margin: 0 }
-nav { background: #444; color: #fff; padding: 0.5em }
-nav a { color: #fff; margin-right: 1em; text-decoration: none }
-nav .user { float: right }
-.content { padding: 1em }
-table { border-collapse: collapse; width: 100% }
-th, td { border: 1px solid #ccc; padding: 0.3em; text-align: left }
-.flashes li.success { color: green }
-.flashes li.error { color: red }
+body { font-family: sans-serif; margin: 0; background: #f4f4f4; }
+nav { background: #2c3e50; color: #fff; padding: 0.7em 1em; }
+nav a { color: #fff; margin-right: 1em; text-decoration: none; }
+nav .logo { font-weight: bold; margin-right: 2em; }
+nav .user { float: right; }
+.content { padding: 1em 2em; }
+table { border-collapse: collapse; width: 100%; background: #fff; }
+th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
+th { background: #eee; }
+tr:nth-child(even) { background: #fafafa; }
+.status-OK { color: green; font-weight: bold; }
+.status-ERROR { color: red; font-weight: bold; }
+.status-UNKNOWN { color: #777; }
+.status-UPDATING, .status-PARTIAL { color: orange; font-weight: bold; }
+.flashes { list-style: none; padding: 0; }
+.flashes li { margin: 0.5em 0; padding: 0.5em; border-radius: 4px; }
+.flashes li.success { background: #e0ffe0; color: #006400; }
+.flashes li.error { background: #ffe0e0; color: #8b0000; }
+.inline { display: inline; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,19 +2,21 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Firmware Maestro</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     </head>
     <body>
         <nav>
-            <a href="{{ url_for('dashboard') }}">Dashboard</a> |
-            <a href="{{ url_for('hosts') }}">Hosts</a> |
-            <a href="{{ url_for('vcenters') }}">vCenters</a> |
-            <a href="{{ url_for('schedules') }}">Schedules</a> |
+            <span class="logo">Firmware Maestro</span>
+            <a href="{{ url_for('dashboard') }}">Dashboard</a>
+            <a href="{{ url_for('hosts') }}">Hosts</a>
+            <a href="{{ url_for('vcenters') }}">vCenters</a>
+            <a href="{{ url_for('schedules') }}">Schedules</a>
             {% if request.user_role == 'Admin' %}
-            <a href="{{ url_for('settings') }}">Settings</a> |
+            <a href="{{ url_for('settings') }}">Settings</a>
             {% endif %}
-            <a href="{{ url_for('help') }}">Help</a> |
+            <a href="{{ url_for('help') }}">Help</a>
             <span class="user">{{ request.user }} ({{ request.user_role }})</span>
         </nav>
         <div class="content">
@@ -29,5 +31,6 @@
             {% endwith %}
             {% block content %}{% endblock %}
         </div>
+        <script src="{{ url_for('static', filename='main.js') }}"></script>
     </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,18 +1,31 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Recent Hosts</h2>
+{% if hosts %}
 <table>
 <tr><th>Hostname</th><th>Status</th><th>Message</th></tr>
 {% for h in hosts %}
-<tr><td>{{ h.hostname }}</td><td>{{ h.last_status }}</td><td>{{ h.last_message }}</td></tr>
+<tr><td>{{ h.hostname }}</td><td class="status-{{ h.last_status }}">{{ h.last_status }}</td><td>{{ h.last_message }}</td></tr>
 {% endfor %}
 </table>
+{% else %}
+<p>No hosts discovered yet.</p>
+{% endif %}
 
 <h2>Schedules</h2>
+{% if schedules %}
 <table>
 <tr><th>Name</th><th>Trigger</th><th>Firmware</th><th>Enabled</th></tr>
 {% for s in schedules %}
-<tr><td>{{ s.name }}</td><td>{{ s.cron or s.interval_minutes ~ 'min' }}</td><td>{{ s.firmware_path }}</td><td>{{ s.enabled }}</td></tr>
+<tr>
+    <td>{{ s.name }}</td>
+    <td>{{ s.cron or (s.interval_minutes ~ ' min') }}</td>
+    <td>{{ s.firmware_path }}</td>
+    <td>{{ 'Yes' if s.enabled else 'No' }}</td>
+</tr>
 {% endfor %}
 </table>
+{% else %}
+<p>No schedules defined.</p>
+{% endif %}
 {% endblock %}

--- a/templates/help.html
+++ b/templates/help.html
@@ -2,5 +2,7 @@
 {% block content %}
 <h2>Help</h2>
 <p>For first time setup run <code>python setup_wizard.py</code>.</p>
+<p>Use the Hosts page to review discovered servers and adjust update policies.</p>
+<p>The Schedules page lets you plan regular firmware updates.</p>
 <p>See README or contact your administrator for further assistance.</p>
 {% endblock %}

--- a/templates/hosts.html
+++ b/templates/hosts.html
@@ -1,19 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Hosts</h2>
+{% if hosts %}
 <table>
 <tr><th>Hostname</th><th>iDRAC IP</th><th>Cluster</th><th>Policy</th><th>Last Status</th><th>Action</th></tr>
 {% for h in hosts %}
-<form action="{{ url_for('update_policy', host_id=h.id) }}" method="post">
+<form class="inline" action="{{ url_for('update_policy', host_id=h.id) }}" method="post">
 <tr>
 <td>{{ h.hostname }}</td>
 <td>{{ h.idrac_ip }}</td>
 <td>{{ h.cluster }}</td>
 <td><input type="text" name="policy" value="{{ h.host_policy or '' }}"></td>
-<td>{{ h.last_status }}</td>
+<td class="status-{{ h.last_status }}">{{ h.last_status }}</td>
 <td><button type="submit">Save</button></td>
 </tr>
 </form>
 {% endfor %}
 </table>
+{% else %}
+<p>No hosts found. Run discovery to populate the inventory.</p>
+{% endif %}
 {% endblock %}

--- a/templates/schedules.html
+++ b/templates/schedules.html
@@ -1,18 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Schedules</h2>
+{% if schedules %}
 <table>
-<tr><th>Name</th><th>Trigger</th><th>Group</th><th>Firmware</th><th>Dry‑run</th></tr>
+<tr><th>Name</th><th>Trigger</th><th>Group</th><th>Firmware</th><th>Dry‑run</th><th>Enabled</th></tr>
 {% for s in schedules %}
 <tr>
 <td>{{ s.name }}</td>
 <td>{{ s.cron or (s.interval_minutes ~ ' min') }}</td>
 <td>{{ s.target_group.name if s.target_group else 'All' }}</td>
 <td>{{ s.firmware_path }}</td>
-<td>{{ s.dry_run }}</td>
+<td>{{ 'Yes' if s.dry_run else 'No' }}</td>
+<td>{{ 'Yes' if s.enabled else 'No' }}</td>
 </tr>
 {% endfor %}
 </table>
+{% else %}
+<p>No schedules created yet.</p>
+{% endif %}
 
 <h3>Create / Update Schedule</h3>
 <form method="post">
@@ -24,9 +29,10 @@ Group:<select name="group_id">
     <option value="{{ g.id }}">{{ g.name }}</option>
     {% endfor %}
 </select>
-Cron:<input name="cron" placeholder="m h dom mon dow">
+Cron:<input name="cron" placeholder="m h dom mon dow e.g. '0 3 * * 0'">
 or Interval (minutes):<input name="interval">
 Dry‑run:<input type="checkbox" name="dry_run">
+Enabled:<input type="checkbox" name="enabled" checked>
 <button type="submit">Save</button>
 </form>
 {% endblock %}

--- a/templates/vcenters.html
+++ b/templates/vcenters.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>vCenters</h2>
+{% if vcenters %}
 <table>
 <tr><th>Name</th><th>URL</th><th>User</th><th>Actions</th></tr>
 {% for vc in vcenters %}
@@ -12,4 +13,7 @@
 </tr>
 {% endfor %}
 </table>
+{% else %}
+<p>No vCenter servers configured.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- refresh UI styling and add responsive layout
- add helpful status colors and empty-state messages
- allow enabling/disabling schedules from the UI
- auto-dismiss flash messages
- show usage tips in help page

## Testing
- `python -m py_compile app.py scheduler.py update.py inventory.py models.py utils.py validators.py setup_wizard.py redfish_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a378e43c832089f0aa1d96b92f23