### PR TITLE
Improve setup wizard and HTTPS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This will prompt for:
 - SMTP server settings
 - vCenter credentials
 - iDRAC credential YAML file path
+- Default iDRAC username and password
 
 It will create the database and populate `.env` with required environment variables.
 

--- a/config.py
+++ b/config.py
@@ -31,4 +31,8 @@ VCENTER_HOST = os.getenv('FM_VC_HOST', 'vcenter.example.com')
 
 IDRAC_CRED_FILE = os.getenv('FM_IDRAC_CRED_FILE', str(BASE_DIR / 'idrac_creds.yaml'))
 
+# Default credentials for newly discovered hosts
+IDRAC_DEFAULT_USER = os.getenv('FM_IDRAC_USER', 'root')
+IDRAC_DEFAULT_PASS = os.getenv('FM_IDRAC_PASS', 'calvin')
+
 LOG_PATH = os.getenv('FM_LOG_PATH', str(BASE_DIR / 'fm.log'))

--- a/update.py
+++ b/update.py
@@ -51,7 +51,12 @@ def apply_firmware(host: Host, fw_path: str, dry_run: bool = False):
     # Enter maintenance for ESXi hosts
     if host.vcenter:
         _enter_maintenance(host.hostname)
-    redfish_obj = RedfishClient(base_url=f"https://{host.idrac_ip}", username="root", password="calvin", default_prefix="/redfish/v1")
+    redfish_obj = RedfishClient(
+        base_url=f"https://{host.idrac_ip}",
+        username=config.IDRAC_DEFAULT_USER,
+        password=config.IDRAC_DEFAULT_PASS,
+        default_prefix="/redfish/v1",
+    )
     try:
         redfish_obj.login()
         response = redfish_obj.simple_update(fw_path)


### PR DESCRIPTION
## Summary
- support default iDRAC creds in config
- enhance setup wizard prompts
- validate vCenter connection during setup
- allow old Flask versions to start scheduler
- use configurable iDRAC creds for updates

## Testing
- `python -m py_compile config.py setup_wizard.py app.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c4622ae08320805fde7e6090d7b4