### PR TITLE
Update README and unify naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ Exit the shell with `quit()` or `Ctrl-D`.
 
 ### 4. Run in Development Mode
 
+Specify the application module when starting Flask:
+
 ```bash
+export FLASK_APP=app.py  # or use --app app.py
 flask run --debug
 ```
 

--- a/app.py
+++ b/app.py
@@ -1,9 +1,9 @@
-"""Firmware Maestro
+"""iDrac Updater
 
 README
 ======
 
-Firmware Maestro is a minimal web‑based firmware‑update orchestrator for Dell iDRAC endpoints.
+iDrac Updater is a minimal web‑based firmware‑update orchestrator for Dell iDRAC endpoints.
 It discovers hosts via Redfish and VMware vCenter, schedules updates with APScheduler,
 and integrates with RHEL IdM/AD trusts using Apache SPNEGO/Kerberos SSO.
 
@@ -14,8 +14,8 @@ Quick start (RHEL 9)
 2. Install system packages:
        sudo dnf install httpd mod_ssl mod_auth_gssapi mod_authnz_ldap python3 python3‑pip gcc
 3. Clone & install:
-       git clone https://example.com/FirmwareMaestro.git
-       cd FirmwareMaestro
+       git clone https://example.com/idrac_updater.git
+       cd idrac_updater
        python3 -m venv venv
        source venv/bin/activate
        pip install -r requirements.txt
@@ -25,7 +25,7 @@ Quick start (RHEL 9)
        flask shell -c "from models import db; db.create_all()"
 6. Run stand‑alone for tests:
        flask run --debug
-7. Deploy behind Apache using the supplied *apache_firmware_maestro.conf* and *wsgi.py*.
+7. Deploy behind Apache using the supplied *apache_idrac_updater.conf* and *wsgi.py*.
 
 For detailed docs see each file’s inline comments.
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-"""Configuration loader for Firmware Maestro.
+"""Configuration loader for iDrac Updater.
 
 Values can be overridden with environment variables or a .env file.
 """

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy models for Firmware Maestro"""
+"""SQLAlchemy models for iDrac Updater"""
 
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -16,9 +16,9 @@ def prompt(question: str, default: str = None, secret: bool = False) -> str:
 
 
 def main():
-    print("=== Firmware Maestro Setup Wizard ===")
+    print("=== iDrac Updater Setup Wizard ===")
     base_dir = Path(__file__).resolve().parent
-    db_path = prompt("Database path", str(base_dir / "firmware_maestro.sqlite"))
+    db_path = prompt("Database path", str(base_dir / "idrac_updater.sqlite"))
     secret_key = prompt("Flask secret key", "change-me")
     admin_group = prompt("Admin group", "FW_MAESTRO_ADMIN")
     operator_group = prompt("Operator group", "FW_MAESTRO_OPERATOR")

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,12 +3,12 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Firmware Maestro</title>
+        <title>iDrac Updater</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     </head>
     <body>
         <nav>
-            <span class="logo">Firmware Maestro</span>
+            <span class="logo">iDrac Updater</span>
             <a href="{{ url_for('dashboard') }}">Dashboard</a>
             <a href="{{ url_for('hosts') }}">Hosts</a>
             <a href="{{ url_for('vcenters') }}">vCenters</a>

--- a/validators.py
+++ b/validators.py
@@ -1,4 +1,4 @@
-"""Input validation helpers for Firmware Maestro."""
+"""Input validation helpers for iDrac Updater."""
 
 import re
 import smtplib


### PR DESCRIPTION
## Summary
- document `FLASK_APP` requirement in the development instructions
- rename `Firmware Maestro` references to `iDrac Updater`

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6887e0de0b948320b8064a74bb30ed93