### PR TITLE
Fix scheduler double start error

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,7 +152,8 @@ def readiness():
 
 def start_scheduler():
     load_schedules()
-    scheduler.start()
+    if not scheduler.running:
+        scheduler.start()
 
 try:
     app.before_first_request(start_scheduler)


### PR DESCRIPTION
## Summary
- avoid SchedulerAlreadyRunningError by checking if APScheduler is running before starting it

## Testing
- `python -m py_compile app.py scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e783944483209eeb63234dcf1af2