### PR TITLE
Fix Python 3.9 type hint syntax

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -8,6 +8,7 @@ from pyVim.connect import SmartConnect, Disconnect
 import ssl
 import config
 from models import db, Host
+from typing import Optional
 
 def discover_idrac_from_list(idrac_list: list[dict]) -> None:
     """Insert or update Host entries based on provided list of dicts {hostname, idrac_ip}"""
@@ -95,7 +96,7 @@ def perform_health_checks():
     db.session.commit()
 
 
-def perform_host_update(host_id: int, firmware_path: str, dry_run: bool, task_id: int | None = None):
+def perform_host_update(host_id: int, firmware_path: str, dry_run: bool, task_id: Optional[int] = None):
     host = Host.query.get(host_id)
     if not host:
         return

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ import requests
 from functools import wraps
 from flask import request, abort
 import config
+from typing import Optional
 
 def get_user_groups(username: str) -> list[str]:
     """Return list of groups the user belongs to using system 'id -Gn' (SSSD cache)."""
@@ -103,7 +104,7 @@ def check_system_health() -> bool:
     return check_database() and check_vcenters()
 
 
-def create_system_backup() -> str | None:
+def create_system_backup() -> Optional[str]:
     """Very basic database backup."""
     import shutil
     from pathlib import Path


### PR DESCRIPTION
## Summary
- add Optional imports where needed
- switch union syntax to Optional for Python 3.9 compatibility

## Testing
- `python -m py_compile inventory.py utils.py`
- `python -m compileall .`
- `python -m flask --app app.py run --host 0.0.0.0 --debug` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6888b013583c8320a2d9dbfae8d857dc