### PR TITLE
fix: add missing error template

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Error {{ error_code }}</h1>
+<p>{{ message }}</p>
+{% if error_code == 404 %}
+<p><a href="{{ url_for('dashboard') }}">Return to Dashboard</a></p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## What & Why
Requests for missing resources crashed with `TemplateNotFound: error.html`. Adding this template lets the error handlers render a friendly page instead of returning a 500.

## Changes
- create `templates/error.html` to display error code and message

## How to test
1. `flask run --host 0.0.0.0 --debug`
2. Visit an invalid URL like `/favicon.ico` and verify error page is shown instead of stack trace

Closes #

------
https://chatgpt.com/codex/tasks/task_e_6888b3a9d64483209d89bf3c97864aa1