### PR TITLE
fix: update navigation links to correct endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -474,6 +474,13 @@ def system_settings():
     
     return render_template("settings.html")
 
+
+@app.route("/help")
+@utils.require_role("Viewer")
+def help_page():
+    """Display help documentation"""
+    return render_template("help.html")
+
 # --- API Endpoints ---
 @app.route("/api/v1/hosts")
 @utils.require_role("Viewer", api=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,13 +10,13 @@
         <nav>
             <span class="logo">iDrac Updater</span>
             <a href="{{ url_for('dashboard') }}">Dashboard</a>
-            <a href="{{ url_for('hosts') }}">Hosts</a>
-            <a href="{{ url_for('vcenters') }}">vCenters</a>
-            <a href="{{ url_for('schedules') }}">Schedules</a>
+            <a href="{{ url_for('host_list') }}">Hosts</a>
+            <a href="{{ url_for('vcenter_list') }}">vCenters</a>
+            <a href="{{ url_for('schedule_list') }}">Schedules</a>
             {% if request.user_role == 'Admin' %}
-            <a href="{{ url_for('settings') }}">Settings</a>
+            <a href="{{ url_for('system_settings') }}">Settings</a>
             {% endif %}
-            <a href="{{ url_for('help') }}">Help</a>
+            <a href="{{ url_for('help_page') }}">Help</a>
             <span class="user">{{ request.user }} ({{ request.user_role }})</span>
         </nav>
         <div class="content">


### PR DESCRIPTION
## What & Why
The navbar referenced outdated endpoint names, causing a `BuildError` when rendering templates. There was also no route for the Help page.

## Changes
- corrected navbar links to use `host_list`, `vcenter_list`, `schedule_list`, and `system_settings`
- added `/help` route with `help_page` view

## How to test
1. Load the Flask app and navigate to any page
2. Verify navigation links work and Help page renders.

Closes #18

------
https://chatgpt.com/codex/tasks/task_e_6888b7024a988320a48732474d50b7d3