### PR TITLE
fix: correct dashboard link in error page

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -3,6 +3,6 @@
 <h1>Error {{ error_code }}</h1>
 <p>{{ message }}</p>
 {% if error_code == 404 %}
-<p><a href="{{ url_for('dashboard') }}">Return to Dashboard</a></p>
+<p><a href="{{ url_for('ui.dashboard_page') }}">Return to Dashboard</a></p>
 {% endif %}
 {% endblock %}

--- a/tests/test_error_template.py
+++ b/tests/test_error_template.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import pytest
+from flask import Flask, render_template
+
+from blueprints.ui import ui_bp
+
+
+@pytest.fixture
+def app(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    app = Flask(
+        __name__,
+        template_folder=str(root / "templates"),
+        static_folder=str(root / "static"),
+    )
+    app.register_blueprint(ui_bp)
+    app.config["TESTING"] = True
+    return app
+
+
+def test_error_template_dashboard_link(app):
+    with app.test_request_context():
+        html = render_template("error.html", error_code=404, message="missing")
+    assert 'href="/dashboard"' in html


### PR DESCRIPTION
## What & Why
The 404 error handler rendered `error.html` which referenced a nonexistent `dashboard` endpoint. This caused a 500 error whenever a missing route (like `/favicon.ico`) was requested.

## Changes
- update `templates/error.html` to reference `ui.dashboard_page`
- add unit test `test_error_template_dashboard_link`

## How to test
1. `pip install -r requirements.txt`
2. `pytest -q`

## Screenshots / Logs
- n/a

## Risks & Mitigations
- None

------
https://chatgpt.com/codex/tasks/task_e_6888e36ce954832097aa0b7a2adc1881